### PR TITLE
Add Flask valuation demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+valuation_app/uploads/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # jeihaan.github.io
+
+This repository contains sample web assets and a small Flask application for a tangible asset valuation demo. The `valuation_app` folder provides a simple interface to upload a Fixed Asset Register and calculate each asset's age based on a valuation date.
+
+## Running the Valuation App
+
+1. Install dependencies:
+   ```bash
+   pip install -r valuation_app/requirements.txt
+   ```
+2. Start the server:
+   ```bash
+   python valuation_app/mainapp.py
+   ```
+3. Open your browser at `http://localhost:5000` and upload your FAR file.
+
+The application expects the register to include an **Asset acquisition date** column and will add an **Asset Age (years)** column to the exported file.

--- a/valuation_app/mainapp.py
+++ b/valuation_app/mainapp.py
@@ -1,0 +1,27 @@
+from flask import Flask, render_template, request, send_file
+import os
+import pandas as pd
+from .valuations import load_far, compute_asset_age
+
+app = Flask(__name__)
+UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        valuation_date = request.form.get('valuation_date')
+        industry = request.form.get('industry')
+        file = request.files.get('far_file')
+        if file and valuation_date:
+            file_path = os.path.join(UPLOAD_FOLDER, file.filename)
+            file.save(file_path)
+            df = load_far(file_path)
+            df = compute_asset_age(df, valuation_date)
+            result_path = os.path.join(UPLOAD_FOLDER, f"result_{file.filename}")
+            df.to_excel(result_path, index=False)
+            return send_file(result_path, as_attachment=True)
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/valuation_app/requirements.txt
+++ b/valuation_app/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+openpyxl

--- a/valuation_app/static/style.css
+++ b/valuation_app/static/style.css
@@ -1,0 +1,15 @@
+body {
+    font-family: Arial, sans-serif;
+    padding: 2em;
+}
+form {
+    display: flex;
+    flex-direction: column;
+    max-width: 400px;
+}
+label {
+    margin-top: 1em;
+}
+button {
+    margin-top: 1em;
+}

--- a/valuation_app/templates/index.html
+++ b/valuation_app/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Tangible Asset Valuation</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Tangible Asset Valuation</h1>
+    <form method="post" enctype="multipart/form-data">
+        <label for="valuation_date">Valuation Date:</label>
+        <input type="date" id="valuation_date" name="valuation_date" required>
+        <label for="industry">Industry:</label>
+        <input type="text" id="industry" name="industry" required>
+        <label for="far_file">Fixed Asset Register (CSV/Excel):</label>
+        <input type="file" id="far_file" name="far_file" accept=".csv,.xls,.xlsx" required>
+        <button type="submit">Calculate</button>
+    </form>
+</body>
+</html>

--- a/valuation_app/valuations.py
+++ b/valuation_app/valuations.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from datetime import datetime
+
+
+def load_far(file_path: str) -> pd.DataFrame:
+    """Load fixed asset register from CSV or Excel file."""
+    if file_path.lower().endswith('.csv'):
+        df = pd.read_csv(file_path)
+    else:
+        df = pd.read_excel(file_path)
+    return df
+
+
+def compute_asset_age(df: pd.DataFrame, valuation_date: str) -> pd.DataFrame:
+    """Add an 'Asset Age (years)' column based on valuation date and acquisition date."""
+    valuation_dt = pd.to_datetime(valuation_date)
+    df['Asset acquisition date'] = pd.to_datetime(df['Asset acquisition date'])
+    df['Asset Age (years)'] = (valuation_dt - df['Asset acquisition date']).dt.days / 365.0
+    return df


### PR DESCRIPTION
## Summary
- add Flask-based valuation demo app
- document running instructions
- ignore Python cache files

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68626db84d7c8325b8b35b0de626f665