### PR TITLE
Add ATO asset category fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ This repository contains sample web assets and a small Flask application for a t
 3. Open your browser at `http://localhost:5000` and upload your FAR file.
 
 The application expects the register to include an **Asset acquisition date** column and will add an **Asset Age (years)** column to the exported file.
+
+## Fetching ATO Asset Categories
+
+The repository includes a helper script to download the industry asset
+categories and their NUL (normal useful life) values from the ATO website.
+Run the script and it will create `valuation_app/ato_asset_categories.json`:
+
+```bash
+python valuation_app/fetch_asset_categories.py
+```

--- a/valuation_app/fetch_asset_categories.py
+++ b/valuation_app/fetch_asset_categories.py
@@ -1,0 +1,43 @@
+import json
+import os
+from typing import Dict, List
+
+import requests
+from bs4 import BeautifulSoup
+
+URL = "https://www.ato.gov.au/law/view/document?DocID=TXR%2FTR20213%2FNAT%2FATO%2F00003"
+
+
+def fetch_asset_categories() -> Dict[str, List[Dict[str, str]]]:
+    """Fetch asset categories from the ATO website and structure them by industry."""
+    response = requests.get(URL)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    data: Dict[str, List[Dict[str, str]]] = {}
+    current_industry: str | None = None
+    for element in soup.find_all(["h3", "table"]):
+        if element.name == "h3":
+            current_industry = element.get_text(strip=True)
+            data[current_industry] = []
+        elif element.name == "table" and current_industry:
+            rows = element.find_all("tr")
+            for row in rows[1:]:
+                cols = [c.get_text(strip=True) for c in row.find_all(["td", "th"])]
+                if len(cols) >= 2:
+                    category = cols[0]
+                    nul = cols[-1]
+                    data[current_industry].append({"category": category, "nul": nul})
+    return data
+
+
+def save_to_json(data: Dict[str, List[Dict[str, str]]]) -> None:
+    """Save the data to ato_asset_categories.json in this package."""
+    output_path = os.path.join(os.path.dirname(__file__), "ato_asset_categories.json")
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    categories = fetch_asset_categories()
+    save_to_json(categories)

--- a/valuation_app/requirements.txt
+++ b/valuation_app/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 pandas
 openpyxl
+beautifulsoup4


### PR DESCRIPTION
## Summary
- add script to download ATO asset categories using requests and BeautifulSoup
- document how to run the script in the README
- include beautifulsoup4 in valuation_app requirements

## Testing
- `python -m py_compile valuation_app/fetch_asset_categories.py`
- `python -m py_compile valuation_app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6862732980508325a07c2f4f90881777