### PR TITLE
Add virtualenv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,42 @@
 
 This repository contains sample web assets and a small Flask application for a tangible asset valuation demo. The `valuation_app` folder provides a simple interface to upload a Fixed Asset Register and calculate each asset's age based on a valuation date.
 
+## Cloning the Repository
+
+Clone the repository and navigate into its directory:
+
+```bash
+git clone https://github.com/jeihaan/jeihaan.github.io.git
+cd jeihaan.github.io
+```
+
+
 ## Running the Valuation App
 
-1. Install dependencies:
+1. Create and activate a virtual environment:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate  # On Windows use "venv\Scripts\activate"
+   ```
+2. Install dependencies inside the virtual environment:
    ```bash
    pip install -r valuation_app/requirements.txt
    ```
-2. Start the server:
+3. Start the server. Use the `-m` flag so Python treats the application as a
+   package (this avoids import issues):
    ```bash
-   python valuation_app/mainapp.py
+   python -m valuation_app.mainapp
    ```
-3. Open your browser at `http://localhost:5000` and upload your FAR file.
+4. Open your browser at `http://localhost:5000` and upload your FAR file.
 
 The application expects the register to include an **Asset acquisition date** column and will add an **Asset Age (years)** column to the exported file.
+
+## Fetching ATO Asset Categories
+
+The repository includes a helper script to download the industry asset
+categories and their NUL (normal useful life) values from the ATO website.
+Run the script and it will create `valuation_app/ato_asset_categories.json`:
+
+```bash
+python valuation_app/fetch_asset_categories.py
+```

--- a/valuation_app/fetch_asset_categories.py
+++ b/valuation_app/fetch_asset_categories.py
@@ -1,0 +1,43 @@
+import json
+import os
+from typing import Dict, List
+
+import requests
+from bs4 import BeautifulSoup
+
+URL = "https://www.ato.gov.au/law/view/document?DocID=TXR%2FTR20213%2FNAT%2FATO%2F00003"
+
+
+def fetch_asset_categories() -> Dict[str, List[Dict[str, str]]]:
+    """Fetch asset categories from the ATO website and structure them by industry."""
+    response = requests.get(URL)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    data: Dict[str, List[Dict[str, str]]] = {}
+    current_industry: str | None = None
+    for element in soup.find_all(["h3", "table"]):
+        if element.name == "h3":
+            current_industry = element.get_text(strip=True)
+            data[current_industry] = []
+        elif element.name == "table" and current_industry:
+            rows = element.find_all("tr")
+            for row in rows[1:]:
+                cols = [c.get_text(strip=True) for c in row.find_all(["td", "th"])]
+                if len(cols) >= 2:
+                    category = cols[0]
+                    nul = cols[-1]
+                    data[current_industry].append({"category": category, "nul": nul})
+    return data
+
+
+def save_to_json(data: Dict[str, List[Dict[str, str]]]) -> None:
+    """Save the data to ato_asset_categories.json in this package."""
+    output_path = os.path.join(os.path.dirname(__file__), "ato_asset_categories.json")
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    categories = fetch_asset_categories()
+    save_to_json(categories)

--- a/valuation_app/mainapp.py
+++ b/valuation_app/mainapp.py
@@ -1,7 +1,11 @@
 from flask import Flask, render_template, request, send_file
 import os
 import pandas as pd
-from .valuations import load_far, compute_asset_age
+try:
+    # When executed as a package (e.g. ``python -m valuation_app.mainapp``)
+    from .valuations import load_far, compute_asset_age
+except ImportError:  # Fallback when running this file directly
+    from valuations import load_far, compute_asset_age
 
 app = Flask(__name__)
 UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')

--- a/valuation_app/requirements.txt
+++ b/valuation_app/requirements.txt
@@ -1,3 +1,5 @@
 Flask
 pandas
 openpyxl
+beautifulsoup4
+requests


### PR DESCRIPTION
## Summary
- document how to run the server inside a virtual environment
- include `requests` in application requirements
- clarify that the app should be executed as a module
- support running `mainapp.py` directly

## Testing
- `python -m py_compile valuation_app/fetch_asset_categories.py && python -m py_compile valuation_app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6862732980508325a07c2f4f90881777