### PR TITLE
Update asset category fetcher with broader level

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,21 @@ The application expects the register to include an **Asset acquisition date** co
 
 ## Fetching ATO Asset Categories
 
-The repository includes a helper script to download the industry asset
-categories and their NUL (normal useful life) values from the ATO website.
-Run the script and it will create `valuation_app/ato_asset_categories.json`:
+The repository includes a helper script to download effective life tables from
+the ATO website. Running it will create `valuation_app/ato_asset_categories.json`
+containing a list of records with the following keys:
+
+* `industry`
+* `sub_industry`
+* `broader_asset_category`
+* `asset_category`
+* `life`
+
+Sub-industry names are derived from the first row of each table in the ATO
+document. When a table contains no broader category headings, the
+`broader_asset_category` value repeats the sub-industry name.
 
 ```bash
 python valuation_app/fetch_asset_categories.py
 ```
+

--- a/valuation_app/fetch_asset_categories.py
+++ b/valuation_app/fetch_asset_categories.py
@@ -1,6 +1,8 @@
+"""Utilities to download effective life tables from the ATO web site."""
+
 import json
 import os
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import requests
 from bs4 import BeautifulSoup
@@ -8,31 +10,68 @@ from bs4 import BeautifulSoup
 URL = "https://www.ato.gov.au/law/view/document?DocID=TXR%2FTR20213%2FNAT%2FATO%2F00003"
 
 
-def fetch_asset_categories() -> Dict[str, List[Dict[str, str]]]:
-    """Fetch asset categories from the ATO website and structure them by industry."""
-    response = requests.get(URL)
+def fetch_asset_categories(url: str = URL) -> List[Dict[str, str]]:
+    """Return a flat list of asset categories with industry info.
+
+    Each item in the returned list contains ``industry``, ``sub_industry``,
+    ``broader_asset_category``, ``asset_category`` and ``life`` keys.
+    """
+
+    response = requests.get(url)
     response.raise_for_status()
     soup = BeautifulSoup(response.text, "html.parser")
 
-    data: Dict[str, List[Dict[str, str]]] = {}
-    current_industry: str | None = None
-    for element in soup.find_all(["h3", "table"]):
+    records: List[Dict[str, str]] = []
+    current_industry: Optional[str] = None
+    current_sub_industry: Optional[str] = None
+    current_broader: Optional[str] = None
+
+    for element in soup.find_all(["h3", "h4", "table"]):
         if element.name == "h3":
             current_industry = element.get_text(strip=True)
-            data[current_industry] = []
+            current_sub_industry = None
+        elif element.name == "h4":
+            current_sub_industry = element.get_text(strip=True)
         elif element.name == "table" and current_industry:
             rows = element.find_all("tr")
-            for row in rows[1:]:
+
+            # The first row may contain the sub-industry name merged across
+            # multiple columns. Detect this by checking for a single cell or a
+            # cell with a ``colspan`` attribute greater than one.
+            data_start = 1
+            if rows:
+                first_cells = rows[0].find_all(["td", "th"])
+                if len(first_cells) == 1 or any(int(c.get("colspan", 1)) > 1 for c in first_cells):
+                    current_sub_industry = rows[0].get_text(strip=True)
+                    # Skip the first two rows (sub-industry heading and column headings)
+                    data_start = 2
+            current_broader = current_sub_industry
+
+            for row in rows[data_start:]:
                 cols = [c.get_text(strip=True) for c in row.find_all(["td", "th"])]
+                if not cols:
+                    continue
+
+                heading = len(cols) == 1 or all(not c for c in cols[1:])
+                first_text = cols[0]
+
+                if heading and first_text.endswith(":"):
+                    current_broader = first_text.rstrip(":").strip()
+                    continue
+
                 if len(cols) >= 2:
-                    category = cols[0]
-                    nul = cols[-1]
-                    data[current_industry].append({"category": category, "nul": nul})
-    return data
+                    records.append({
+                        "industry": current_industry,
+                        "sub_industry": current_sub_industry or "",
+                        "broader_asset_category": current_broader or (current_sub_industry or ""),
+                        "asset_category": first_text,
+                        "life": cols[-1],
+                    })
+    return records
 
 
-def save_to_json(data: Dict[str, List[Dict[str, str]]]) -> None:
-    """Save the data to ato_asset_categories.json in this package."""
+def save_to_json(data: List[Dict[str, str]]) -> None:
+    """Save the records to ``ato_asset_categories.json`` in this package."""
     output_path = os.path.join(os.path.dirname(__file__), "ato_asset_categories.json")
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- document new `broader_asset_category` field in the README
- capture table headings as broader asset categories when scraping ATO tables

## Testing
- `python -m py_compile valuation_app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68628187ecc48325b00b5b554149555f